### PR TITLE
feat: extend `useStableO` to support an optional `Eq` argument

### DIFF
--- a/src/ref.ts
+++ b/src/ref.ts
@@ -1,0 +1,10 @@
+import * as E from 'fp-ts/Either';
+import { Eq } from 'fp-ts/Eq';
+import * as O from 'fp-ts/Option';
+import { Dispatch, SetStateAction, useReducer, useRef as useRef_ } from 'react';
+
+export const useRef = <A>(a: A, eq: Eq<A>): A => {
+  const ref = useRef_<A>(a);
+  if (!eq.equals(ref.current, a)) ref.current = a
+  return ref.current;
+}

--- a/src/ref.ts
+++ b/src/ref.ts
@@ -1,10 +1,9 @@
-import * as E from 'fp-ts/Either';
 import { Eq } from 'fp-ts/Eq';
-import * as O from 'fp-ts/Option';
-import { Dispatch, SetStateAction, useReducer, useRef as useRef_ } from 'react';
+import { useRef as useRef_ } from 'react';
 
-export const useRef = <A>(a: A, eq: Eq<A>): A => {
+export const useStableRef = <A>(a: A, eq: Eq<A>): A => {
   const ref = useRef_<A>(a);
-  if (!eq.equals(ref.current, a)) ref.current = a
+  if (!eq.equals(ref.current, a))
+    ref.current = a;
   return ref.current;
-}
+};

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,21 +1,37 @@
-import * as E from 'fp-ts/Either';
-import * as Eq from 'fp-ts/Eq';
-import * as O from 'fp-ts/Option';
 import { Dispatch, SetStateAction, useReducer } from 'react';
+
+import * as E from 'fp-ts/Either';
+import { eqStrict } from "fp-ts/Eq"
+import * as O from 'fp-ts/Option';
+
+import type { Eq } from "fp-ts/Eq"
+import type { Either } from 'fp-ts/lib/Either'
+import type { Option } from 'fp-ts/Option'
 
 const isSetStateFn = <A>(s: SetStateAction<A>): s is (a: A) => A => typeof s === 'function';
 
-export const useStable = <A>(initState: A, eq: Eq.Eq<A>): [A, Dispatch<SetStateAction<A>>] =>
+type StateTuple<A> = [A, Dispatch<SetStateAction<A>>];
+
+export const useStable = <A>(initState: A, eq: Eq<A>): StateTuple<A> =>
   useReducer(
-    (s1: A, s2: SetStateAction<A>) => {
-      const _s2 = isSetStateFn(s2) ? s2(s1) : s2;
+    (...[s1, s2]: StateTuple<A>) => {
+      const _s2 = isSetStateFn<A>(s2) ? s2(s1) : s2;
       return eq.equals(s1, _s2) ? s1 : _s2;
     },
     initState
   );
 
-export const useStableO = <A>(initState: O.Option<A>): [O.Option<A>, Dispatch<SetStateAction<O.Option<A>>>] =>
-  useStable(initState, O.getEq(Eq.eqStrict));
+export function useStableO<A>(initState: Option<A>): StateTuple<Option<A>>
+export function useStableO<A>(initState: Option<A>, eq: Eq<A>): StateTuple<Option<A>>
+export function useStableO<A>(initState: Option<A>, eq?: Eq<A>): StateTuple<Option<A>> {
+  const eq_ = eq ?? eqStrict
+  return useStable(initState, O.getEq(eq_))
+}
 
-export const useStableE = <E, A>(initState: E.Either<E, A>): [E.Either<E, A>, Dispatch<SetStateAction<E.Either<E, A>>>] =>
-  useStable(initState, E.getEq(Eq.eqStrict, Eq.eqStrict));
+export function useStableE<E, A>(initState: Either<E, A>): StateTuple<Either<E, A>>
+export function useStableE<E, A>(initState: Either<E, A>, leftEq: Eq<E>, rightEq: Eq<A>): StateTuple<Either<E, A>>
+export function useStableE<E, A>(initState: Either<E, A>, leftEq?: Eq<E>, rightEq?: Eq<A>): StateTuple<Either<E, A>> {
+  if (leftEq && rightEq) return useStable(initState, E.getEq(leftEq, rightEq))
+  else return useStable(initState, E.getEq(eqStrict, eqStrict))
+}
+


### PR DESCRIPTION
Currently users can only provide primitive values to `useStableO`, which means it effectively doesn't support Options containing any non-primitive types.

The current workaround is to use `useStable` and manually wrap the `Eq` in `O.getEq`. Handling this for users is the reason `useStableO` exists, so it seems counter-intuitive to have users drop down to a lower-level construct, especially since it's not immediately obvious that that combination is how we support this use case.

It would be nice if `useStableO` supported this out of the box.

This PR extends `useStableO` to support this use case by adding an optional second argument to `useStableO`, which is the custom `Eq` that, if provided, will be used to determine whether state should be updated. 

By having the argument default to `Eq.eqStrict`, this new behavior is opt-in. Things will continue working as before for existing users, so a minor bump is all that's necessary.

I can add tests and documentation if this is a change y'all think makes sense, and I'm happy to make whatever adjustments that are requested during review.

===

I also added `useStableRef`, which works the same way as `useStable`: setting `ref.current` will only succeed when the values are different according to the `Eq` they provided. I think it probably makers sense for that to be in a separate PR, but I thought it would be useful to get feedback on the addition.